### PR TITLE
Use new Rollbar initialization method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var rollbar = require("rollbar");
+var Rollbar = require("rollbar");
 
 module.exports = {
   install: function(Vue, options) {
-    Vue.rollbar = rollbar.init(options);
+    Vue.rollbar = new Rollbar(options);
   }
 };


### PR DESCRIPTION
This replaces the old `rollbar.init` with `new Rollbar` as explained in [Rollbar's documentation](https://github.com/rollbar/rollbar.js#upgrading-from-node_rollbar)