### PR TITLE
Assign to Vue.prototype for component access

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@ var Rollbar = require("rollbar");
 module.exports = {
   install: function(Vue, options) {
     Vue.rollbar = new Rollbar(options);
+    Vue.prototype.rollbar = Vue.rollbar;
   }
 };


### PR DESCRIPTION
Otherwise `this.rollbar.error` is undefined in component:

```
created () {
  this.rollbar.error('uh oh')
}
```